### PR TITLE
Fix gtk error

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 // Bom, esse e um codigp basico, ele cria uma janela com 800x600
 const { app, createApp, BrowserWindow } = require("electron");
+const { join } = require("path");
 
 const createWindow = () => {
   const win = new BrowserWindow({
@@ -7,7 +8,7 @@ const createWindow = () => {
     height: 600,
   });
 
-  win.loadFile("web/index.html");
+  win.loadFile(join(app.getAppPath(), "web/index.html"));
 };
 
 app.whenReady().then(() => {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "type": "commonjs",
   "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
   "devDependencies": {
-    "electron": "^36.2.1"
+    "electron": "^35.1.5"
   }
 }


### PR DESCRIPTION
- Decrement electron version to fix gtk error.
- Prepend app path on html file path, this is for the path to work when compiled/packaged.